### PR TITLE
fix a template error and redirect

### DIFF
--- a/carrent/carrentapp/templates/carrentapp/order_confirm_delete.html
+++ b/carrent/carrentapp/templates/carrentapp/order_confirm_delete.html
@@ -3,7 +3,7 @@
 
 <section class="top-hero projects-hero" xmlns="http://www.w3.org/1999/html">
     <p class="top-hero-text text-light mb-0" style="font-size: 5rem; height: 40%; text-align: center">Na pewno usunąć?</p>
-    <p class="top-hero-text text-light mt-0" style="font-size: 3rem; height: 40%; text-align: center">{{ request.session.car_brand }} {{ request.session.car_model }}</p>
+    <p class="top-hero-text text-light mt-0" style="font-size: 3rem; height: 40%; text-align: center">{{ object.car.brand.brand_name }} {{ object.car.car_model }}</p>
     <div class="hero-shadow bg-dark bg-gradient" style="height: 80%"></div>
 </section>
 

--- a/carrent/carrentapp/views.py
+++ b/carrent/carrentapp/views.py
@@ -205,7 +205,7 @@ class OrderDeleteView(RestrictOwnerAccessMixin, DeleteView):
     model = Order
 
     def get_success_url(self):
-        return reverse('actual_order')
+        return reverse('future_order')
 
 
 class OrderDetailView(RestrictOwnerAccessMixin, DetailView):


### PR DESCRIPTION
Goal: To fix an error with order delete template where hero bar car name was being wrongly read form session data

additional goals:
- change redirect after deletion from "actual orders" to "future orders" 