### PR TITLE
Fix bug in employee car return filter pagination

### DIFF
--- a/carrent/employee/views.py
+++ b/carrent/employee/views.py
@@ -67,7 +67,7 @@ class OrderFilter(django_filters.FilterSet):
 class CarReturnListView(StaffStatusRequiredMixin, ListView):
     model = Order
     template_name = 'employee/employee_car_return.html'
-    paginate_by = 1
+    paginate_by = 10
 
     def get_queryset(self):
         orders = Order.objects.filter(return_date=date.today(), status=OrderStatus.AKTYWNY)
@@ -95,6 +95,10 @@ class CarReturnListView(StaffStatusRequiredMixin, ListView):
                 "is_paginated": False,
                 "object_list": fltr.qs,
             }
+
+        _request_copy = self.request.GET.copy()
+        parameters = _request_copy.pop('page', True) and _request_copy.urlencode()
+        context['parameters'] = parameters
 
         kwargs.setdefault('view', self)
         kwargs.update(fltr_dict)

--- a/carrent/employee/views.py
+++ b/carrent/employee/views.py
@@ -67,7 +67,7 @@ class OrderFilter(django_filters.FilterSet):
 class CarReturnListView(StaffStatusRequiredMixin, ListView):
     model = Order
     template_name = 'employee/employee_car_return.html'
-    paginate_by = 10
+    paginate_by = 1
 
     def get_queryset(self):
         orders = Order.objects.filter(return_date=date.today(), status=OrderStatus.AKTYWNY)
@@ -77,10 +77,10 @@ class CarReturnListView(StaffStatusRequiredMixin, ListView):
         fltr = OrderFilter(self.request.GET, queryset=self.get_queryset())
         fltr_dict = {'filter': fltr}
 
-        page_size = self.get_paginate_by(fltr.queryset)
+        page_size = self.get_paginate_by(fltr.qs)
         if page_size:
             paginator, page, queryset, is_paginated = self.paginate_queryset(
-                fltr.queryset, page_size
+                fltr.qs, page_size
             )
             context = {
                 "paginator": paginator,
@@ -93,7 +93,7 @@ class CarReturnListView(StaffStatusRequiredMixin, ListView):
                 "paginator": None,
                 "page_obj": None,
                 "is_paginated": False,
-                "object_list": fltr.queryset,
+                "object_list": fltr.qs,
             }
 
         kwargs.setdefault('view', self)


### PR DESCRIPTION
Goal: to fix a bug with filtering and pagination

Bug:
- Wrong querryset was being sent to the context because filter.qs is not filter.queryset
- filter data was being lost when changing pages (because filter data is transfered via url)