### PR TITLE
Change anuluj button functionality

### DIFF
--- a/carrent/accounts/templates/accounts/profile.html
+++ b/carrent/accounts/templates/accounts/profile.html
@@ -75,7 +75,7 @@
                                 <td>{{ user_form.mobile_nr }}</td>
                             </tr>
                         </table>
-                            <button type="reset" class="btn btn-dark btn-lg" style="font-size: large">Anuluj</button>
+                            <a href="{% url 'main' %}" class="btn btn-dark btn-lg" role="button" style="font-size: large">Anuluj</a>
                             <button type="submit" class="btn btn-success btn-lg bg-gradient" style="font-size: large">Zapisz zmiany</button>
                             <a href="{% url 'password_change' %}" class="btn btn-warning btn-lg bg-gradient" role="button" style="font-size: large">Zmień hasło</a>
                             {% csrf_token %}


### PR DESCRIPTION
goal: the "anuluj" button should cancel and exit the view instead of resetting the form`s initial values to the current state

Why:
At first, it seemed handy to be able to reset your form if you made some errors but in practice it prooved to never be used.
Some type of back/exit button was needed and 4 buttons seemed too much, hence my decision to remove the reset button entirely and insert the button that redirects to main page in its place 